### PR TITLE
support non-redirect-with-cookies auth flow

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,16 @@
+# Authentication and authorization
+
+Some notes on how we handle authentication and authorization. In general, we focus little on authorization since most objects in the game are public. Some simple filtering is used to check for mutations to user data or shared objects like game state.
+
+## Discord
+
+The primary authentication method for the game is through Discord. The plumbing is there to implement our own authorization server, but we feel that engagement will be much higher via OAuth2.
+
+We have two applications registered with Discord:
+
+- [`monarchy`](https://discord.com/developers/applications/1323331352283709491/oauth2) - the main application, used for production
+- [`monarchy-staging`](https://discord.com/developers/applications/1325545581304614912/oauth2) - a separate application for test environments
+
+## Future work
+
+We can add other OAuth2 providers. A field to track the OpenID of the `user` will be added. Then adding new mappings from public keys to an issuing service should be straightforward.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,4 +1,4 @@
-# Backend Architecture
+# Backend architecture
 
 `monarchy-api` is a JVM application written in Scala 2.13. It exposes a GraphQL
 API over HTTP and support websocket connections.

--- a/server/src/controllers/DiscordAuthorizeController.scala
+++ b/server/src/controllers/DiscordAuthorizeController.scala
@@ -9,12 +9,36 @@ class DiscordAuthorizeController(implicit
     ec: ExecutionContext,
     exchangeCli: ExchangeClient
 ) extends GetController {
-  import DiscordExchangeController._
+  import DiscordAuthorizeController._
 
   def action(ctx: AuthContext): Future[HttpResponse] = {
-    val stateJson = Json.stringify(State(referrerUrl = "http://localhost:8081"))
-    exchangeCli.fetchAuthorizeUrl(stateJson).map { url =>
+    val query = Uri.Query(ctx.request.request.uri.rawQueryString)
+    val callerContext = mkCallerContext(query)
+    val contextJson = Json.stringify(callerContext)
+    exchangeCli.fetchAuthorizeUrl(contextJson).map { url =>
       HttpResponse(StatusCodes.TemporaryRedirect, headers = List(headers.Location(url)))
     }
+  }
+}
+
+object DiscordAuthorizeController {
+  private[controllers] def isLocal: Boolean =
+    sys.env.get("ENV").nonEmpty
+
+  /**
+   * A caller context defines under what conditions the authorization flow is
+   * initiated. This can have important UX implications. We can later add 
+   * support for some custom base 64 data here as well.
+   *
+   * @param referrerUrl the URL of the calling client, if any
+   * @param embedded whether the caller is embedded on the OS (aka native app)
+   */
+  case class CallerContext(referrerUrl: String, embedded: Boolean)
+
+  private def mkCallerContext(query: Uri.Query): CallerContext = {
+    val referrerDefaultUrl = if (isLocal) "http://localhost:8081" else "https://monarchy1.com"
+    val referrerUrl = query.getOrElse("referrerUrl", "https")
+    val embedded = query.get("embedded").nonEmpty
+    CallerContext(referrerUrl = referrerUrl, embedded = embedded)
   }
 }

--- a/server/src/web/DiscordModule.scala
+++ b/server/src/web/DiscordModule.scala
@@ -19,11 +19,11 @@ object DiscordModule {
     sys.env.getOrElse("DISCORD_REDIRECT_URL", "http://localhost:8080/oauth2/discord/exchange")
 
   private object Config extends Oauth2.Config(
-    baseUrl = "https://discord.com/api/oauth2",
+    baseUrl = "https://discord.com/api/v10/oauth2",
     clientId = clientId,
     clientSecret = clientSecret,
     redirectUri = redirectUrl,
-    scopes = Set("identify", "openid") // consider also: "email", "guilds"
+    scopes = Set("identify", "email", "openid") // consider also: "guilds"
   )
 
   def exchangeClient(


### PR DESCRIPTION
**Testing**
Here are some credentials returned for the staging app.
* Notice that the `access_token` is not a JWT
* This means we cannot perform offline-token-validation, since the token is opaque
* This means if Discord goes down we can no longer authenticate requests
* This also means, to authenticate a request using the token, Discord is on the hot path


```json
{
  "token_type": "Bearer",
  "access_token": "jIfJWtftMYBNhnsr[...]aAQuIhGah",
  "expires_in": 604800
}
```